### PR TITLE
Collect all violations instead of short-circuiting.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,15 +27,20 @@ inThisBuild(
 )
 
 val pgvVersion = "0.3.0"
+val munitSettings = Seq(
+  libraryDependencies += "org.scalameta" %% "munit" % "0.7.9" % Test,
+  testFrameworks += new TestFramework("munit.Framework")
+)
 
 lazy val core = projectMatrix
   .in(file("core"))
   .settings(stdSettings)
+  .settings(munitSettings)
   .settings(
     name := "scalapb-validate-core",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0"),
-      "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0") % "protobuf"
+      "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0") % "protobuf",
     )
   )
   .jvmPlatform(scalaVersions = Seq(Scala212, Scala213))
@@ -69,6 +74,7 @@ lazy val e2e = projectMatrix
   .dependsOn(core)
   .enablePlugins(LocalCodeGenPlugin)
   .settings(stdSettings)
+  .settings(munitSettings)
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(Scala212, Scala213),
@@ -76,9 +82,7 @@ lazy val e2e = projectMatrix
     libraryDependencies ++= Seq(
       "io.undertow" % "undertow-core" % "2.1.3.Final",
       "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % pgvVersion % "protobuf",
-      "org.scalameta" %% "munit" % "0.7.9" % Test
     ),
-    testFrameworks += new TestFramework("munit.Framework"),
     PB.targets in Compile := Seq(
       scalapb.gen(grpc = true) -> (sourceManaged in Compile).value / "scalapb",
       genModule("scalapb.validate.compiler.CodeGenerator$") ->

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val core = projectMatrix
     name := "scalapb-validate-core",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0"),
-      "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0") % "protobuf",
+      "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0") % "protobuf"
     )
   )
   .jvmPlatform(scalaVersions = Seq(Scala212, Scala213))
@@ -81,7 +81,7 @@ lazy val e2e = projectMatrix
     codeGenClasspath := (codeGenJVM212 / Compile / fullClasspath).value,
     libraryDependencies ++= Seq(
       "io.undertow" % "undertow-core" % "2.1.3.Final",
-      "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % pgvVersion % "protobuf",
+      "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % pgvVersion % "protobuf"
     ),
     PB.targets in Compile := Seq(
       scalapb.gen(grpc = true) -> (sourceManaged in Compile).value / "scalapb",

--- a/core/src/main/scala/scalapb/validate/Validator.scala
+++ b/core/src/main/scala/scalapb/validate/Validator.scala
@@ -8,7 +8,7 @@ sealed trait Result {
   def isFailure: Boolean
   def toFailure: Option[Failure]
 
-  def &&(other: => Result): Result =
+  def &&(other: Result): Result =
     (this, other) match {
       case (Success, Success)              => Success
       case (Success, f: Failure)           => f

--- a/core/src/main/scala/scalapb/validate/Validator.scala
+++ b/core/src/main/scala/scalapb/validate/Validator.scala
@@ -8,14 +8,20 @@ sealed trait Result {
   def isFailure: Boolean
   def toFailure: Option[Failure]
 
-  def &&(other: => Result) = if (isSuccess) other else this
+  def &&(other: => Result): Result =
+    (this, other) match {
+      case (Success, Success)              => Success
+      case (Success, f: Failure)           => f
+      case (f: Failure, Success)           => f
+      case (Failure(left), Failure(right)) => Failure(left ::: right)
+    }
 }
 
 object Result {
   def run[T](code: => T): Result =
     Try(code) match {
       case scala.util.Success(_)                      => Success
-      case scala.util.Failure(e: ValidationException) => Failure(e)
+      case scala.util.Failure(e: ValidationException) => Failure(e :: Nil)
       case scala.util.Failure(ex) =>
         throw new RuntimeException(
           s"Unexpected exception. Please report this as a bug: ${ex.getMessage()}",
@@ -23,14 +29,18 @@ object Result {
         )
     }
 
-  def apply(cond: => Boolean, onError: => ValidationException) =
-    if (cond) Success else Failure(onError)
+  def apply(cond: => Boolean, onError: => ValidationException): Result =
+    if (cond) Success else Failure(onError :: Nil)
 
   def optional[T](value: Option[T])(eval: T => Result): Result =
     value.fold[Result](Success)(eval)
 
-  def repeated[T](value: Iterable[T])(eval: T => Result) =
-    value.iterator.map(eval).find(_.isFailure).getOrElse(Success)
+  def collect(results: Iterable[Result]): Result =
+    results.foldLeft[Result](Success) { case (left, right) => left && right }
+
+  def repeated[T](value: Iterable[T])(eval: T => Result): Result =
+    collect(value.map(eval))
+
 }
 
 case object Success extends Result {
@@ -39,10 +49,14 @@ case object Success extends Result {
   def toFailure: Option[Failure] = None
 }
 
-case class Failure(violation: ValidationException) extends Result {
+case class Failure(violations: List[ValidationException]) extends Result {
   def isSuccess: Boolean = false
   def isFailure: Boolean = true
   def toFailure: Option[Failure] = Some(this)
+}
+
+object Failure {
+  def apply(violation: ValidationException): Failure = Failure(violation :: Nil)
 }
 
 trait Validator[T] {

--- a/core/src/test/scala/scalapb/validate/ResultSpec.scala
+++ b/core/src/test/scala/scalapb/validate/ResultSpec.scala
@@ -1,0 +1,113 @@
+package scalapb.validate
+
+import io.envoyproxy.pgv.ValidationException
+
+class ResultSpec extends munit.FunSuite {
+
+  test("Success is success") {
+    assertEquals(Success.isSuccess, true)
+    assertEquals(Success.isFailure, false)
+    assertEquals(Success.toFailure, None)
+  }
+
+  test("Failure is failure") {
+    val failure = Failure(new ValidationException("field", 42, "reason"))
+    assertEquals(failure.isSuccess, false)
+    assertEquals(failure.isFailure, true)
+    assertEquals(failure.toFailure, Some(failure))
+  }
+
+  test("Result && Result") {
+    val failure = Failure(new ValidationException("field", 42, "reason"))
+    val otherFailure = Failure(new ValidationException("field2", 24, "reason"))
+    assertEquals(Success && Success, Success)
+    assertEquals(Success && failure, failure)
+    assertEquals(failure && Success, failure)
+    assertEquals(
+      failure && otherFailure,
+      Failure(failure.violations ::: otherFailure.violations)
+    )
+    assertEquals(
+      otherFailure && failure,
+      Failure(otherFailure.violations ::: failure.violations)
+    )
+  }
+
+  test("Result.apply") {
+    val exception = new ValidationException("field", 42, "reason")
+    assertEquals(
+      Result(true, sys.error("failure branch should be lazy")),
+      Success
+    )
+    assertEquals(Result(false, exception), Failure(exception))
+  }
+
+  test("Result.optional") {
+    val exception = new ValidationException("field", 42, "reason")
+    assertEquals(
+      Result.optional(Some("value")) { value =>
+        assertEquals(value, "value")
+        Success
+      },
+      Success
+    )
+    assertEquals(
+      Result.optional(Some("value")) { value =>
+        assertEquals(value, "value")
+        Failure(exception)
+      },
+      Failure(exception)
+    )
+    assertEquals(
+      Result.optional[String](None) { _ =>
+        sys.error("failure branch should be lazy")
+      },
+      Success
+    )
+  }
+
+  test("Result.collect") {
+    val failure = Failure(new ValidationException("field", 42, "reason"))
+    val otherFailure = Failure(new ValidationException("field2", 24, "reason"))
+    assertEquals(Result.collect(Nil), Success)
+    assertEquals(Result.collect(Success :: Nil), Success)
+    assertEquals(Result.collect(Success :: Success :: Nil), Success)
+    assertEquals(Result.collect(Success :: failure :: Nil), failure)
+    assertEquals(
+      Result.collect(Success :: failure :: otherFailure :: Nil),
+      failure && otherFailure
+    )
+    assertEquals(
+      Result.collect(failure :: otherFailure :: Success :: Nil),
+      failure && otherFailure
+    )
+    assertEquals(
+      Result.collect(otherFailure :: failure :: Success :: Nil),
+      otherFailure && failure
+    )
+  }
+
+  test("Result.repeated") {
+    val failure = Failure(new ValidationException("field", 42, "reason"))
+    val otherFailure = Failure(new ValidationException("field2", 24, "reason"))
+    assertEquals(
+      Result.repeated(Nil)(_ => sys.error("cannot be invoked")),
+      Success
+    )
+    assertEquals(Result.repeated(Success :: Nil)(identity), Success)
+    assertEquals(Result.repeated(Success :: Success :: Nil)(identity), Success)
+    assertEquals(Result.repeated(Success :: failure :: Nil)(identity), failure)
+    assertEquals(
+      Result.repeated(Success :: failure :: otherFailure :: Nil)(identity),
+      failure && otherFailure
+    )
+    assertEquals(
+      Result.repeated(failure :: otherFailure :: Success :: Nil)(identity),
+      failure && otherFailure
+    )
+    assertEquals(
+      Result.repeated(otherFailure :: failure :: Success :: Nil)(identity),
+      otherFailure && failure
+    )
+  }
+}

--- a/e2e/src/test/scala/scalapb/validate/ScalaHarness.scala
+++ b/e2e/src/test/scala/scalapb/validate/ScalaHarness.scala
@@ -102,7 +102,13 @@ object ScalaHarness {
     val inst = testCase.getMessage.unpack(cmp)
     val result = vtor.validate(inst) match {
       case Success => TestResult(valid = true)
-      case Failure(ex) =>
+      case Failure(Nil) => // could be avoided with a NonEmptyList
+        sys.error(
+          "unexpected empty violation list"
+        )
+      case Failure(
+            ex :: _ // ignores multiple violations since pgv only supports one
+          ) =>
         val allowFailure =
           ex.getReason() == MapValidation.SPARSE_MAPS_NOT_SUPPORTED
         TestResult(

--- a/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
+++ b/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
@@ -3,6 +3,19 @@ package scalapb.validate
 import examplepb.example.Person
 
 class ValidatorSpec extends munit.FunSuite {
+
+  def assertFailure[T](r: Result, expected: List[(String, AnyRef)])(implicit
+      loc: munit.Location
+  ) =
+    r match {
+      case Success => fail("expected a Failure, but was a Success")
+      case Failure(violations) =>
+        val fieldAndValues = violations.map { v =>
+          v.getField -> v.getValue
+        }
+        assertEquals(fieldAndValues, expected)
+    }
+
   val testPerson = Person(
     id = 1000,
     email = "foo@bar.com",
@@ -14,6 +27,19 @@ class ValidatorSpec extends munit.FunSuite {
     assertEquals(
       Validator[Person].validate(testPerson),
       Success
+    )
+  }
+  test("Person invalid email") {
+    assertFailure(
+      Validator[Person].validate(testPerson.copy(email = "not an email")),
+      ("email", "\"not an email\"") :: Nil
+    )
+  }
+  test("Person invalid email and age") {
+    assertFailure(
+      Validator[Person]
+        .validate(testPerson.copy(email = "not an email", age = -1)),
+      ("email", "\"not an email\"") :: ("age", Int.box(-1)) :: Nil
     )
   }
 }


### PR DESCRIPTION
Short-cuirting validation helps performance, but it is typically more ergonomic for clients when they are provided with all violations. In fact, the Google's [`BadRequest` type](https://github.com/googleapis/googleapis/blob/e2c0f2a/google/rpc/error_details.proto#L166-L180) which [`pgv` uses](https://github.com/envoyproxy/protoc-gen-validate/blob/bcadd58/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidationExceptions.java) allows specifying multiple violations.

More tests should be written around the `Result` type, but this is submitted to solicit feedback first.