### PR TITLE
Compatibility with `sealed_value` feature

### DIFF
--- a/e2e/src/main/protobuf/example.proto
+++ b/e2e/src/main/protobuf/example.proto
@@ -25,3 +25,18 @@ message Person {
 
   fixed32 age = 6 [(validate.rules).fixed32 = {gte:30, lt: 40}];
 }
+
+message Cat {
+  Person food_provider = 1 [(validate.rules).message.required = true];
+}
+message Dog {
+  Person master = 1 [(validate.rules).message.required = true];
+}
+
+message Animal {
+  oneof sealed_value {
+    option (validate.required) = true;
+    Cat cat = 1;
+    Dog dog = 2;
+  }
+}


### PR DESCRIPTION
When using `sealed_value`, the compiler fails with the following error:

```
[error] examplepb/example/Cat.scala: Tried to insert into file that doesn't exist.
[error] examplepb/example/Dog.scala: Tried to insert into file that doesn't exist.
```

Presumably, because the generated type is no longer in its own top-level file due to the behaviour of `sealed_value`.

NOTE: this is only adding a failing test case to demonstrate the issue. I can take a stab at fixing this with some additional guidance.