### PR TITLE
Throw a more specific exception when validating a proto

### DIFF
--- a/core/src/main/scala/scalapb/validate/Validator.scala
+++ b/core/src/main/scala/scalapb/validate/Validator.scala
@@ -84,7 +84,7 @@ object Validator {
       case Success =>
       case Failure(violations) =>
         throw new ValidationException(
-          "Validation failed: " + violations.map(_.toString()).mkString(", ")
+          "Validation failed: " + violations.map(_.getMessage()).mkString(", ")
         )
     }
 }

--- a/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
+++ b/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
@@ -58,7 +58,7 @@ class ValidatorSpec extends munit.FunSuite with ValidationHelpers {
 
   test("assertValid raises an Exception if the object is invalid") {
     interceptMessage[ValidationException](
-      "Validation failed: io.envoyproxy.pgv.ValidationException: Person.email: should be a valid email - Got \"not an email\", io.envoyproxy.pgv.ValidationException: Person.age: -1 must be in the range [30, 40) - Got -1"
+      "Validation failed: Person.email: should be a valid email - Got \"not an email\", Person.age: -1 must be in the range [30, 40) - Got -1"
     ) {
       Validator.assertValid(testPerson.copy(email = "not an email", age = -1))(
         Validator[Person]

--- a/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
+++ b/e2e/src/test/scala/scalapb/validate/ValidatorSpec.scala
@@ -51,4 +51,18 @@ class ValidatorSpec extends munit.FunSuite with ValidationHelpers {
     )
 
   }
+
+  test("assertValid does nothing if the object is valid") {
+    Validator.assertValid(testPerson)(Validator[Person])
+  }
+
+  test("assertValid raises an Exception if the object is invalid") {
+    interceptMessage[ValidationException](
+      "Validation failed: io.envoyproxy.pgv.ValidationException: Person.email: should be a valid email - Got \"not an email\", io.envoyproxy.pgv.ValidationException: Person.age: -1 must be in the range [30, 40) - Got -1"
+    ) {
+      Validator.assertValid(testPerson.copy(email = "not an email", age = -1))(
+        Validator[Person]
+      )
+    }
+  }
 }


### PR DESCRIPTION
Raises a dedicated exception in `Validator.assertValid` to let client handle this exception in a specific manner.
Improves slightly the exception message.