### PR TITLE
fix: don't pull in scalapb runtime in the compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,6 @@ lazy val codeGen = projectMatrix
     name := "scalapb-validate-codegen",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "compilerplugin" % scalapbVersion,
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf",
       "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0") % "protobuf",
       "com.thesamet.scalapb.common-protos" %% "pgv-proto-scalapb_0.10" % (pgvVersion + "-0")


### PR DESCRIPTION
The scalapb runtime and compiler do not declare the same `protobuf-java` dependency.
By declaring a dependency on the runtime here, we sometimes get the `scalapb-runtime` version (3.11.4) on the classpath instead of the `compilerplugin` version (3.12.2).

It's not clear what steps are necessary to reproduce this, but this line was determined to be the culprit that led sbt to do this:

```
com.google.protobuf:protobuf-java:3.11.4
com.google.protobuf:protobuf-java:3.12.2 (evicted by: 3.11.4)
```

It appears to be caused by some ordering of plugins that sbt resolves.
In any case, this dependency does not need to be declared and so it can safely be removed.