### PR TITLE
Reproducing compilation error with sealed oneofs and required = true

### DIFF
--- a/e2e/src/main/protobuf/oneof_example.proto
+++ b/e2e/src/main/protobuf/oneof_example.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package examplepb;
+
+import "validate/validate.proto";
+
+message Expr {
+  oneof sealed_value {
+    Literal lit = 1;
+    Add add = 2;
+    Mul mul = 3;
+  }
+}
+
+message Literal {
+  int32 value = 1;
+}
+
+message Add {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message Mul {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message Program {
+  Expr expr = 1 [(validate.rules).message.required = true];
+  repeated Expr exprs = 2;
+}


### PR DESCRIPTION
This proto triggers and compilation error

```
[error] /home/joao/git/scalapb-validate/e2e/target/jvm-2.12/src_managed/main/scalapb/examplepb/oneof_example/ProgramValidator.scala:6:22: overloaded method value apply with alternatives:
[error]   [T](name: String, value: scalapb.GeneratedOneof)scalapb.validate.Result <and>
[error]   [T](name: String, value: Option[T])scalapb.validate.Result
[error]  cannot be applied to (String, examplepb.oneof_example.ExprMessage)
[error]     scalapb.validate.RequiredValidation("Program.expr", examplepb.oneof_example.Program._typemapper_expr.toBase(input.expr)) &&
[error]
```

and `ProgramValidator.scala` is

```scala
package examplepb.oneof_example

object ProgramValidator extends scalapb.validate.Validator[examplepb.oneof_example.Program] {
  def validate(input: examplepb.oneof_example.Program): scalapb.validate.Result =
    examplepb.oneof_example.ExprMessageValidator.validate(examplepb.oneof_example.Program._typemapper_expr.toBase(input.expr))&&
    scalapb.validate.RequiredValidation("Program.expr", examplepb.oneof_example.Program._typemapper_expr.toBase(input.expr)) &&
    scalapb.validate.Result.repeated(input.exprs.iterator.map(examplepb.oneof_example.Program._typemapper_exprs.toBase)) { _value =>
      examplepb.oneof_example.ExprMessageValidator.validate(_value)
    }
  
}
```

One solution to make the code above compile would be to add `.sealedValue` when handling a sealed oneof, but I was not able to do it myself...

```scala
package examplepb.oneof_example

object ProgramValidator extends scalapb.validate.Validator[examplepb.oneof_example.Program] {
  def validate(input: examplepb.oneof_example.Program): scalapb.validate.Result =
    examplepb.oneof_example.ExprMessageValidator.validate(examplepb.oneof_example.Program._typemapper_expr.toBase(input.expr))&&
    scalapb.validate.RequiredValidation("Program.expr", examplepb.oneof_example.Program._typemapper_expr.toBase(input.expr).sealedValue) && //change here
    scalapb.validate.Result.repeated(input.exprs.iterator.map(examplepb.oneof_example.Program._typemapper_exprs.toBase)) { _value =>
      examplepb.oneof_example.ExprMessageValidator.validate(_value)
    }
  
}
```