### PR TITLE
fix warning in refined package object

### DIFF
--- a/e2e/src/main/scala-2/scalapb/transforms/refined/package.scala
+++ b/e2e/src/main/scala-2/scalapb/transforms/refined/package.scala
@@ -6,7 +6,9 @@ import eu.timepit.refined.api.{Refined, Validate}
 import scalapb.validate.ValidationException
 
 package object refined {
-  implicit def refinedType[T, V](implicit ev: Validate[T, V]) =
+  implicit def refinedType[T, V](implicit
+      ev: Validate[T, V]
+  ): TypeMapper[T, Refined[T, V]] =
     TypeMapper[T, Refined[T, V]](refineV(_) match {
       case Left(error)  => throw new ValidationException(error)
       case Right(value) => value


### PR DESCRIPTION
add explicit type

```
[warn] /home/runner/work/scalapb-validate/scalapb-validate/e2e/src/main/scala-2/scalapb/transforms/refined/package.scala:9:16: Implicit definition should have explicit type (inferred scalapb.TypeMapper[T,eu.timepit.refined.api.Refined[T,V]])
[warn]   implicit def refinedType[T, V](implicit ev: Validate[T, V]) =
[warn]                ^
```