### PR TITLE
fix e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
 
     - uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: 11
         distribution: temurin
     - name: Compile and test
       run: |
-        sbt "core${{matrix.scala}}/test" "codeGen${{matrix.scala}}/test" "e2e${{matrix.scala}}/test" "e2e${{matrix.scala}}/test:runMain scalapb.validate.ScalaHarness"
+        sbt "core${{matrix.scala}}/test" "codeGen${{matrix.scala}}/test" "e2e${{matrix.scala}}/test" "e2e${{matrix.scala}}/Test/runMain scalapb.validate.ScalaHarness"
 
     - name: Formatting
       run: |

--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,8 @@ lazy val e2e = projectMatrix
   .settings(stdSettings)
   .settings(munitSettings)
   .settings(
+    run / baseDirectory := (LocalRootProject / baseDirectory).value,
+    run / fork := true,
     publish / skip := true,
     crossScalaVersions := Seq(Scala212, Scala213),
     codeGenClasspath := (codeGenJVM212 / Compile / fullClasspath).value,


### PR DESCRIPTION
- fix warning. `test:runMain` => `Test/runMain`

```
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: e2eJVM3 / Test / runMain
```

- use JDK 11 instead of 8 due to `undertow` dependency

```
[info] running scalapb.validate.ScalaHarness 
Error: Exception in thread "sbt-bg-threads-1" java.lang.UnsupportedClassVersionError: io/undertow/server/HttpServerExchange has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

- change `run / baseDirecotory` for `executor.exe` path
